### PR TITLE
Mejora en `package.json` y limpieza de instrucciones redundantes en el README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,0 @@
-## Dependencias
-```
-   npm i express
-   npm i cors
-   npm i dotenv
-```

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Comando para tests no especificado (de momento)\" && exit 1"
   },
   "keywords": [],
   "author": "",
@@ -12,6 +13,11 @@
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.5.0"
   }
 }


### PR DESCRIPTION
## `package.json`
- Agregado `"type": "module"` para poder usar la sintaxis de los ES modules, los imports y exports más bonitos
- Agregadas a las dependencias de desarrollo los tipos de node y express. Aunque no estemos usando TypeScript, VSCode (y probablemente más programas) dan mejor autocompletado al tenerlas
- Agregado `zod` a las dependencias, ya que lo vamos a usar para validar

## `readme.md`
- Sección "dependencias" borrada. El `package.json` ya especifica las dependencias y la versión de cada una, es mucho mejor ejecutar `npm i` que hacer `npm i [nombre]` para cada dependencia