### PR TITLE
TypeScript + Archivo principal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist/
 node_modules/
 package-lock.json
 .env

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
     "test": "echo \"Comando para tests no especificado (de momento)\" && exit 1"
   },
   "keywords": [],
@@ -17,7 +19,9 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
-    "@types/node": "^22.5.0"
+    "@types/node": "^22.5.0",
+    "typescript": "^5.5.4"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+const PORT = process.env.PORT ?? 3000;
+
+app.disable('x-powered-by');
+app.use(express.json());
+app.use(cors());
+
+app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2022",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "removeComments": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "moduleResolution": "node",
+    "strictPropertyInitialization": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
Cambios para pasar el proyecto a TypeScript:
- Creado `tsconfig.json`
- Añadido typescript y los tipos de cors (se me olvidaron la otra vez) a las devDependencies
- Creados un par de scripts para agilizar el trabajo (`build` para compilar y `start` para arrancar el servidor)

Y el editor me indicaba un error porque no había código, así que de paso he creado el archivo principal para el proyecto

Por favor, revisad todo bien y sugerid los cambios a `tsconfig.json` que veáis convenientes